### PR TITLE
Changing all arguments to be primitive types

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Tasks performed by this pass:
 
 All `infile` arguments default to accept stdin, so commands can be chained like so:
 ```bash
-openaps use pump read_history_data 0 | openaps use mmhistorytools clean --start 2015-06-13T17:37:58 | openaps use mmhistorytools reconcile | openaps use mmhistorytools resolve --now 2015-06-13T21:37:58 | openaps use mmhistorytools normalize --basal-profile basal.json --zero-at 2015-06-21T15:37:58
+openaps use pump read_history_data 0 | openaps use munge clean --start 2015-06-13T17:37:58 | openaps use munge reconcile | openaps use munge resolve --now 2015-06-13T21:37:58 | openaps use munge normalize --basal-profile basal.json --zero-at 2015-06-21T21:37:58
 ```
 
 ## Motivation

--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -8,7 +8,6 @@ from .version import __version__
 import argparse
 from dateutil.parser import parse
 import json
-import sys
 
 from openaps.uses.use import Use
 
@@ -77,7 +76,7 @@ class BaseUse(Use):
         parser.add_argument(
             'infile',
             nargs='?',
-            default=sys.stdin,
+            default='-',
             help='JSON-encoded history data'
         )
 
@@ -125,7 +124,10 @@ Tasks performed by this pass:
 
     def get_program(self, params):
         args, kwargs = super(clean, self).get_program(params)
-        kwargs.update(start_datetime=_opt_date(params.start), end_datetime=_opt_date(params.end))
+        kwargs.update(
+            start_datetime=_opt_date(params['start']),
+            end_datetime=_opt_date(params['end'])
+        )
 
         return args, kwargs
 
@@ -145,7 +147,7 @@ Tasks performed by this pass:
  - Duplicates and modifies temporary basal records to account for delivery pauses when suspended
     """
     def main(self, args, app):
-        args, _ = self.get_program(args)
+        args, _ = self.get_program(self.get_params(args))
 
         tool = ReconcileHistory(*args)
 
@@ -190,7 +192,7 @@ Events that are not related to the record types or seem to have no effect are dr
         return args, kwargs
 
     def main(self, args, app):
-        args, kwargs = self.get_program(args)
+        args, kwargs = self.get_program(self.get_params(args))
 
         tool = ResolveHistory(*args, **kwargs)
 

--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -50,7 +50,7 @@ def _opt_date(timestamp):
     :return: A datetime object if a timestamp was specified
     :rtype: datetime.datetime|NoneType
     """
-    if timestamp is not None:
+    if timestamp:
         return parse(timestamp)
 
 
@@ -62,7 +62,7 @@ def _opt_json_file(filename):
     :return: A decoded JSON object if a filename was specified
     :rtype: dict|list|NoneType
     """
-    if filename is not None:
+    if filename:
         return json.load(argparse.FileType('r')(filename))
 
 
@@ -118,15 +118,20 @@ Tasks performed by this pass:
 
     def get_params(self, args):
         params = super(clean, self).get_params(args)
-        params.update(start=args.start, end=args.end)
+
+        if args.start:
+            params.update(start=args.start)
+
+        if args.end:
+            params.update(end=args.end)
 
         return params
 
     def get_program(self, params):
         args, kwargs = super(clean, self).get_program(params)
         kwargs.update(
-            start_datetime=_opt_date(params['start']),
-            end_datetime=_opt_date(params['end'])
+            start_datetime=_opt_date(params.get('start')),
+            end_datetime=_opt_date(params.get('end'))
         )
 
         return args, kwargs
@@ -181,13 +186,15 @@ Events that are not related to the record types or seem to have no effect are dr
 
     def get_params(self, args):
         params = super(resolve, self).get_params(args)
-        params.update(now=args.now)
+
+        if args.now:
+            params.update(now=args.now)
 
         return params
 
     def get_program(self, params):
         args, kwargs = super(resolve, self).get_program(params)
-        kwargs.update(current_datetime=_opt_date(params['now']))
+        kwargs.update(current_datetime=_opt_date(params.get('now')))
 
         return args, kwargs
 
@@ -225,18 +232,19 @@ integers representing the number of minutes from `--zero-at`.
 
     def get_params(self, args):
         params = super(normalize, self).get_params(args)
-        params.update(
-            basal_profile=args.basal_profile,
-            zero_at=args.zero_at
-        )
+        if args.basal_profile:
+            params.update(basal_profile=args.basal_profile)
+
+        if args.zero_at:
+            params.update(zero_at=args.zero_at)
 
         return params
 
     def get_program(self, params):
         args, kwargs = super(normalize, self).get_program(params)
         kwargs.update(
-            basal_schedule=_opt_json_file(args['basal_profile']),
-            zero_datetime=_opt_date(args['zero_at'])
+            basal_schedule=_opt_json_file(params.get('basal_profile')),
+            zero_datetime=_opt_date(params.get('zero_at'))
         )
 
         return args, kwargs


### PR DESCRIPTION
To support serialization in openaps-report.

Fixes #4 