### PR TITLE
Resolve Exercise Markers

### DIFF
--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -215,6 +215,7 @@ Each record is a dictionary representing one of the following types, as denoted 
 - `Bolus`: Insulin delivery events in Units, or Units/hour
 - `Meal`: Grams of carbohydrate
 - `TempBasal`: Paced insulin delivery events in Units/hour, or Percent of scheduled basal
+- `Exercise`: Exercise event
 The following history events are parsed:
 - TempBasal and TempBasalDuration are combined into TempBasal records
 - PumpSuspend and PumpResume are combined into TempBasal records of 0%
@@ -222,6 +223,7 @@ The following history events are parsed:
 - Normal Bolus is converted to a Bolus record
 - BolusWizard carb entry is converted to a Meal record
 - JournalEntryMealMarker is converted to a Meal record
+- JournalEntryExerciseMarker is converted to an Exercise record
 Events that are not related to the record types or seem to have no effect are dropped.
 """
     def main(self, args, app):

--- a/openapscontrib/mmhistorytools/historytools.py
+++ b/openapscontrib/mmhistorytools/historytools.py
@@ -1,4 +1,4 @@
-hfrom collections import defaultdict
+from collections import defaultdict
 from copy import copy
 from datetime import datetime
 from datetime import timedelta

--- a/openapscontrib/mmhistorytools/historytools.py
+++ b/openapscontrib/mmhistorytools/historytools.py
@@ -356,7 +356,7 @@ class ResolveHistory(ParseHistory):
             end_at=start_at,
             amount=num_events,
             unit=Unit.event,
-            description='{}'.format(event["_type"])
+            description=event["_type"]
         )        
 
     def _decode_pumpresume(self, event):

--- a/openapscontrib/mmhistorytools/historytools.py
+++ b/openapscontrib/mmhistorytools/historytools.py
@@ -356,7 +356,7 @@ class ResolveHistory(ParseHistory):
             end_at=start_at,
             amount=num_events,
             unit=Unit.event,
-            description='{}: {}event'.format(event["_type"], num_events)
+            description='{}'.format(event["_type"])
         )        
 
     def _decode_pumpresume(self, event):

--- a/openapscontrib/mmhistorytools/historytools.py
+++ b/openapscontrib/mmhistorytools/historytools.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
+hfrom collections import defaultdict
 from copy import copy
 from datetime import datetime
 from datetime import timedelta
 from dateutil import parser
 
-from .models import Bolus, Meal, TempBasal, Unit
+from .models import Bolus, Meal, TempBasal, Exercise, Unit
 
 
 class ParseHistory(object):
@@ -254,6 +254,7 @@ class ResolveHistory(ParseHistory):
     - `Bolus`: Insulin delivery events in Units, or Units/hour
     - `Meal`: Grams of carbohydrate
     - `TempBasal`: Paced insulin delivery events in Units/hour, or Percent of scheduled basal
+    - `Exercise`: Exercise event
 
     The following history events are parsed:
 
@@ -263,6 +264,7 @@ class ResolveHistory(ParseHistory):
     - Normal Bolus is converted to a Bolus record
     - BolusWizard carb entry is converted to a Meal record
     - JournalEntryMealMarker is converted to a Meal record
+    - JournalEntryExerciseMarker is converted to an Exercise record
 
     Events that are not related to the record types or seem to have no effect are dropped.
     """
@@ -344,6 +346,18 @@ class ResolveHistory(ParseHistory):
                 unit=Unit.grams,
                 description='{}: {}g'.format(event["_type"], carb_input)
             )
+
+    def _decode_journalentryexercisemarker(self, event):
+        num_events = 1
+        start_at = self._event_datetime(event)
+
+        return Exercise(
+            start_at=start_at,
+            end_at=start_at,
+            amount=num_events,
+            unit=Unit.event,
+            description='{}: {}event'.format(event["_type"], num_events)
+        )        
 
     def _decode_pumpresume(self, event):
         self._resume_datetime = self._event_datetime(event)

--- a/openapscontrib/mmhistorytools/models.py
+++ b/openapscontrib/mmhistorytools/models.py
@@ -41,11 +41,16 @@ class TempBasal(BaseRecord):
     pass
 
 
+class Exercise(BaseRecord):
+    pass
+
+
 class Unit(object):
     grams = "g"
     percent_of_basal = "percent"
     units = "U"
     units_per_hour = "U/hour"
+    event = "event"
 
 
 class RecordJSONEncoder(json.JSONEncoder):

--- a/tests/fixtures/exercise_marker.json
+++ b/tests/fixtures/exercise_marker.json
@@ -1,0 +1,10 @@
+[
+  {
+    "_type": "JournalEntryExerciseMarker", 
+    "_description": "JournalEntryExerciseMarker 2015-09-07T15:38:23 head[2], body[1] op[0x41]", 
+    "timestamp": "2015-09-07T15:38:23", 
+    "_body": "00", 
+    "_head": "4100", 
+    "_date": "97660f070f"
+  }
+]

--- a/tests/historytools_tests.py
+++ b/tests/historytools_tests.py
@@ -10,7 +10,7 @@ from openapscontrib.mmhistorytools.historytools import NormalizeRecords
 from openapscontrib.mmhistorytools.historytools import ReconcileHistory
 from openapscontrib.mmhistorytools.historytools import ResolveHistory
 from openapscontrib.mmhistorytools.historytools import TrimHistory
-from openapscontrib.mmhistorytools.models import Bolus, Meal, TempBasal
+from openapscontrib.mmhistorytools.models import Bolus, Meal, TempBasal, Exercise
 
 
 def get_file_at_path(path):
@@ -809,6 +809,27 @@ class ResolveHistoryTestCase(unittest.TestCase):
                 )
             ],
             [r for r in h.resolved_records if r["type"] == "Bolus"]
+        )
+    
+    def test_exercise_marker(self):
+        with open(get_file_at_path("fixtures/exercise_marker.json")) as fp:
+            pump_history = json.load(fp)
+
+        h = ResolveHistory(pump_history)
+
+        _ = parser.parse
+
+        self.assertListEqual(
+            [
+                Exercise(
+                    start_at=_("2015-09-07T15:38:23"),
+                    end_at=_("2015-09-07T15:38:23"),
+                    amount=1,
+                    unit="event",
+                    description="JournalEntryExerciseMarker: 1event"
+                )
+            ],
+            h.resolved_records
         )
 
 

--- a/tests/historytools_tests.py
+++ b/tests/historytools_tests.py
@@ -826,7 +826,7 @@ class ResolveHistoryTestCase(unittest.TestCase):
                     end_at=_("2015-09-07T15:38:23"),
                     amount=1,
                     unit="event",
-                    description="JournalEntryExerciseMarker: 1event"
+                    description="JournalEntryExerciseMarker"
                 )
             ],
             h.resolved_records


### PR DESCRIPTION
See: https://github.com/loudnate/openaps-mmhistorytools/issues/25

`JournalEntryExerciseMarker` events are now resolved into `Exercise` records, with `amount` of `1` and `unit` of `Event`. Start and end times are identical (single timestamp).