### PR TITLE
append_dose command

### DIFF
--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -315,7 +315,7 @@ If that key isn't present, or its value is false, the record is ignored.
     def get_params(self, args):
         params = super(append_dose, self).get_params(args)
 
-        params.update(doses=args.dose)
+        params.update(dose=args.dose)
 
         return params
 

--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -308,7 +308,7 @@ If that key isn't present, or its value is false, the record is ignored.
         super(append_dose, self).configure_app(app, parser)
 
         parser.add_argument(
-            '--dose', '--doses',
+            '--dose',
             help='JSON-encoded dosing report'
         )
 
@@ -322,7 +322,7 @@ If that key isn't present, or its value is false, the record is ignored.
     def get_program(self, params):
         args, kwargs = super(append_dose, self).get_program(params)
 
-        args.append(_opt_json_file(params['doses']))
+        args.append(_opt_json_file(params['dose']))
 
         return args, kwargs
 

--- a/openapscontrib/mmhistorytools/__init__.py
+++ b/openapscontrib/mmhistorytools/__init__.py
@@ -300,11 +300,8 @@ integers representing the number of minutes from `--zero-at`.
 class append_dose(BaseUse):
     """Appends a dose record to a sequence of cleaned history
 
-If `--basal-profile` is provided, the TempBasal `amount` is replaced with a relative dose in
-Units/hour. A single TempBasal record might split into multiple records to account for boundary
-crossings in the basal schedule.
-If `--zero-at` is provided, the values for the `start_at` and `end_at` keys are replaced with signed
-integers representing the number of minutes from `--zero-at`.
+The expected dose record format is a dictionary with a key named "recieved" (sic).
+If that key isn't present, or its value is false, the record is ignored.
 """
 
     def configure_app(self, app, parser):
@@ -325,7 +322,7 @@ integers representing the number of minutes from `--zero-at`.
     def get_program(self, params):
         args, kwargs = super(append_dose, self).get_program(params)
 
-        args.append(params['doses'])
+        args.append(_opt_json_file(params['doses']))
 
         return args, kwargs
 

--- a/openapscontrib/mmhistorytools/historytools.py
+++ b/openapscontrib/mmhistorytools/historytools.py
@@ -357,7 +357,7 @@ class ResolveHistory(ParseHistory):
             amount=num_events,
             unit=Unit.event,
             description=event["_type"]
-        )        
+        )
 
     def _decode_pumpresume(self, event):
         self._resume_datetime = self._event_datetime(event)
@@ -583,3 +583,46 @@ class NormalizeRecords(object):
                 )
 
                 return events
+
+
+class AppendDoseToHistory(ParseHistory):
+    """Append a dose record or records to a list of history records.
+
+    The expected dose record format is a dictionary with a key named "recieved" (sic).
+    If that key isn't present, or its value is false, the record is ignored.
+    """
+    def __init__(self, clean_history, doses):
+        """Initializes a new instance of the history parser
+
+        :param clean_history: A list of pump history events in reverse-chronological order
+        :type clean_history: list(dict)
+        :param doses: A single dose event, or a list of dose events in chronological order
+        :type doses: list(dict)|dict
+        """
+        self.appended_history = clean_history
+
+        if isinstance(doses, dict):
+            doses = [doses]
+
+        for event in doses:
+            if event.get('recieved', False) is True:
+                self.add_history_event(event)
+
+    def add_history_event(self, event):
+        try:
+            decoded = getattr(self, '_decode_{}'.format(event['type'].lower()))(event)
+        except AttributeError:
+            decoded = [event]
+
+        for decoded_event in decoded:
+            self.appended_history.insert(0, decoded_event)
+
+    def _decode_tempbasal(self, event):
+        amount_event = copy(event)
+        amount_event['_type'] = amount_event.pop('type')
+
+        duration_event = copy(event)
+        duration_event['_type'] = '{}Duration'.format(duration_event.pop('type'))
+        duration_event[self.DURATION_IN_MINUTES_KEY] = duration_event.pop('duration')
+
+        return [amount_event, duration_event]

--- a/tests/fixtures/set_dose.json
+++ b/tests/fixtures/set_dose.json
@@ -1,0 +1,10 @@
+[
+  {
+    "temp": "absolute",
+    "recieved": true,
+    "rate": 1.425,
+    "timestamp": "2015-09-19T20:25:27.468623",
+    "duration": 30,
+    "type": "TempBasal"
+  }
+]

--- a/tests/fixtures/set_two_doses.json
+++ b/tests/fixtures/set_two_doses.json
@@ -1,0 +1,18 @@
+[
+  {
+    "temp": "percent",
+    "recieved": true,
+    "rate": 100,
+    "timestamp": "2015-07-27T16:45:29.737754",
+    "duration": 0,
+    "type": "TempBasal"
+  },
+  {
+    "temp": "percent",
+    "recieved": true,
+    "rate": 140,
+    "timestamp": "2015-07-27T16:45:31.320183",
+    "duration": 30,
+    "type": "TempBasal"
+  }
+]

--- a/tests/historytools_tests.py
+++ b/tests/historytools_tests.py
@@ -5,6 +5,7 @@ import json
 import os
 import unittest
 
+from openapscontrib.mmhistorytools.historytools import AppendDoseToHistory
 from openapscontrib.mmhistorytools.historytools import CleanHistory
 from openapscontrib.mmhistorytools.historytools import NormalizeRecords
 from openapscontrib.mmhistorytools.historytools import ReconcileHistory
@@ -810,7 +811,7 @@ class ResolveHistoryTestCase(unittest.TestCase):
             ],
             [r for r in h.resolved_records if r["type"] == "Bolus"]
         )
-    
+
     def test_exercise_marker(self):
         with open(get_file_at_path("fixtures/exercise_marker.json")) as fp:
             pump_history = json.load(fp)
@@ -1514,4 +1515,192 @@ class MungeFixturesTestCase(BasalScheduleTestCase):
                 }
             ],
             records
+        )
+
+
+class AppendDoseToHistoryTestCase(unittest.TestCase):
+    def test_append_single_dose(self):
+        with open(get_file_at_path('fixtures/set_dose.json')) as fp:
+            doses = json.load(fp)
+
+        h = AppendDoseToHistory([{'_type': 'Foo'}], doses)
+
+        self.assertListEqual(
+            [
+                {
+                    '_type': 'TempBasalDuration',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration (min)': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'TempBasal',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'Foo'
+                }
+            ],
+            h.appended_history
+        )
+
+    def test_append_single_dose_dict(self):
+        with open(get_file_at_path('fixtures/set_dose.json')) as fp:
+            doses = json.load(fp)
+
+        h = AppendDoseToHistory([{'_type': 'Foo'}], doses[0])
+
+        self.assertListEqual(
+            [
+                {
+                    '_type': 'TempBasalDuration',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration (min)': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'TempBasal',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'Foo'
+                }
+            ],
+            h.appended_history
+        )
+
+    def test_append_single_dose_to_long_history(self):
+        with open(get_file_at_path('fixtures/square_bolus.json')) as fp:
+            pump_history = json.load(fp)
+
+        with open(get_file_at_path('fixtures/set_dose.json')) as fp:
+            doses = json.load(fp)
+
+        h = AppendDoseToHistory(pump_history, doses)
+
+        self.assertListEqual(
+            [
+                {
+                    '_type': 'TempBasalDuration',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration (min)': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'TempBasal',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    'programmed': 1.6,
+                    '_type': 'Bolus',
+                    '_description': 'Bolus 2015-06-19T23:04:25 head[8], body[0] op[0x01]',
+                    'timestamp': '2015-06-19T23:04:25',
+                    '_body': '',
+                    '_head': '010040004000ac00',
+                    'amount': 1.6,
+                    'unabsorbed': 4.3,
+                    'duration': 0,
+                    'type': 'normal',
+                    '_date': '598457730f'
+                }
+            ],
+            h.appended_history[:3]
+        )
+
+    def test_append_single_dose_to_empty_history(self):
+        with open(get_file_at_path('fixtures/set_dose.json')) as fp:
+            doses = json.load(fp)
+
+        h = AppendDoseToHistory([], doses)
+
+        self.assertListEqual(
+            [
+                {
+                    '_type': 'TempBasalDuration',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration (min)': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                },
+                {
+                    '_type': 'TempBasal',
+                    'timestamp': '2015-09-19T20:25:27.468623',
+                    'duration': 30,
+                    'recieved': True,
+                    'temp': 'absolute',
+                    'rate': 1.425
+                }
+            ],
+            h.appended_history
+        )
+
+    def test_append_no_dose(self):
+        h = AppendDoseToHistory([{'_type': 'Foo'}], [])
+
+        self.assertListEqual([{'_type': 'Foo'}], h.appended_history)
+
+    def test_append_multiple_doses(self):
+        with open(get_file_at_path('fixtures/set_two_doses.json')) as fp:
+            doses = json.load(fp)
+
+        h = AppendDoseToHistory([{'_type': 'Foo'}], doses)
+
+        self.assertListEqual(
+            [
+                {
+                    '_type': 'TempBasalDuration',
+                    'temp': 'percent',
+                    'recieved': True,
+                    'rate': 140,
+                    'timestamp': '2015-07-27T16:45:31.320183',
+                    'duration (min)': 30
+                },
+                {
+                    '_type': 'TempBasal',
+                    'temp': 'percent',
+                    'recieved': True,
+                    'rate': 140,
+                    'timestamp': '2015-07-27T16:45:31.320183',
+                    'duration': 30
+                },
+                {
+                    '_type': 'TempBasalDuration',
+                    'temp': 'percent',
+                    'recieved': True,
+                    'rate': 100,
+                    'timestamp': '2015-07-27T16:45:29.737754',
+                    'duration (min)': 0
+                },
+                {
+                    '_type': 'TempBasal',
+                    'temp': 'percent',
+                    'recieved': True,
+                    'rate': 100,
+                    'timestamp': '2015-07-27T16:45:29.737754',
+                    'duration': 0
+                },
+                {
+                    '_type': 'Foo'
+                }
+            ],
+            h.appended_history
         )


### PR DESCRIPTION
Adding a new command which appends the contents of a dosing report (e.g. `temp_basal.json`) to history, so it can be re-processed for display.